### PR TITLE
Updated links

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ zero_to_docs
 
 A repository for guiding you in setting up your own documentation. You can follow these materials along with the template repository here:
 
-* https://github.com/docathon/sphinx_template
+* https://github.com/docathon/sphinx-template
 
 Right now, the repository begins with a set of skeleton materials. These guides cover the following topics:
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ zero_to_docs
 
 A repository for guiding you in setting up your own documentation. You can follow these materials along with the template repository here:
 
-* https://github.com/choldgraf/sphinx_template
+* https://github.com/docathon/sphinx_template
 
 Right now, the repository begins with a set of skeleton materials. These guides cover the following topics:
 

--- a/getting_started_with_sphinx.ipynb
+++ b/getting_started_with_sphinx.ipynb
@@ -40,7 +40,7 @@
    "outputs": [],
    "source": [
     "%%bash\n",
-    "git clone https://github.com/choldgraf/sphinx_template ../sphinx_template"
+    "git clone https://github.com/docathon/sphinx-template ../sphinx_template"
    ]
   },
   {
@@ -50,7 +50,7 @@
     "editable": true
    },
    "source": [
-    "* [Here's a link to this repository](https://github.com/choldgraf/sphinx_template)\n",
+    "* [Here's a link to this repository](https://github.com/docathon/sphinx-template)\n",
     "\n",
     "This is a fully-functioning sphinx template. However, since we're doing a demo, we'll clear everything out!"
    ]
@@ -648,21 +648,21 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 2",
    "language": "python",
-   "name": "python3"
+   "name": "python2"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 3
+    "version": 2
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.5.2"
+   "pygments_lexer": "ipython2",
+   "version": "2.7.13"
   }
  },
  "nbformat": 4,

--- a/setting_up_sphinx_gallery.ipynb
+++ b/setting_up_sphinx_gallery.ipynb
@@ -9,7 +9,7 @@
    "source": [
     "# Setting up [sphinx-gallery](https://github.com/sphinx-gallery/sphinx-gallery)\n",
     "\n",
-    "* Template repo: https://github.com/choldgraf/sphinx_template\n",
+    "* Template repo: https://github.com/docathon/sphinx-template\n",
     "\n",
     "Sphinx-gallery allows you to generate beautiful visualizations of data in a single gallery of images. Here are a few examples of what you can do with sphinx-gallery:\n",
     "\n",
@@ -693,21 +693,21 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 2",
    "language": "python",
-   "name": "python3"
+   "name": "python2"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 3
+    "version": 2
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.5.2"
+   "pygments_lexer": "ipython2",
+   "version": "2.7.13"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
replaced links to the (now empty) choldgraf/sphinx_template with links to docathon/sphinx-template 